### PR TITLE
Yas test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,19 @@ include_directories(${avro_PREFIX}/include)
 set(AVRO_LIBRARIES ${avro_PREFIX}/lib/libavrocpp_s.a)
 set(AVRO_GENERATOR ${avro_PREFIX}/bin/avrogencpp)
 
+set(yas_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/yas)
+ExternalProject_Add(
+    yas
+    DEPENDS boost
+    PREFIX ${yas_PREFIX}
+#    URL "https://github.com/niXman/yas/archive/master.zip"
+    URL "https://github.com/pmed/yas/archive/improve-shared_buffer.zip"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND mkdir -p ${yas_PREFIX}/include/ && cp -r ${yas_PREFIX}/src/yas/include/yas ${yas_PREFIX}/include/
+)
+include_directories(${yas_PREFIX}/include)
+
 find_package(HPX REQUIRED)
 
 set(LINKLIBS    ${THRIFT_LIBRARIES}
@@ -240,6 +253,8 @@ set(CEREAL_SERIALIZATION_SOURCES ${cpp_serializers_SOURCE_DIR}/cereal/record.cpp
 
 set(HPX_SERIALIZATION_SOURCES ${cpp_serializers_SOURCE_DIR}/hpx/record.cpp)
 set(HPX_ZERO_COPY_SERIALIZATION_SOURCES ${cpp_serializers_SOURCE_DIR}/hpx_zero_copy/record.cpp)
+ 
+set(YAS_SERIALIZATION_SOURCES ${cpp_serializers_SOURCE_DIR}/yas/record.cpp)
 
 add_executable(test ${cpp_serializers_SOURCE_DIR}/test.cpp
                     ${THRIFT_SERIALIZATION_SOURCES}
@@ -250,8 +265,9 @@ add_executable(test ${cpp_serializers_SOURCE_DIR}/test.cpp
                     ${AVRO_SERIALIZATION_SOURCES}
                     ${HPX_SERIALIZATION_SOURCES}
                     ${HPX_ZERO_COPY_SERIALIZATION_SOURCES}
+                    ${YAS_SERIALIZATION_SOURCES}
 )
-add_dependencies(test thrift msgpack protobuf capnproto ${BOOST_DEPENDENCY} cereal avro hpx)
+add_dependencies(test thrift msgpack protobuf capnproto ${BOOST_DEPENDENCY} cereal avro hpx yas)
 target_link_libraries(test ${LINKLIBS})
 set_target_properties(test PROPERTIES COMPILE_FLAGS "-O3")
 if(MPI_FOUND)

--- a/test.cpp
+++ b/test.cpp
@@ -33,6 +33,7 @@
 #include "hpx/record.hpp"
 #include "hpx_zero_copy/record.hpp"
 #include "mpi/record.hpp"
+#include "yas/record.hpp"
 
 #include "data.hpp"
 
@@ -474,7 +475,6 @@ void hpx_zero_copy_serialization_test(size_t iterations)
     std::cout << "hpx_zero_copy: time = " << duration << " milliseconds" << std::endl << std::endl;
 }
 
-
 void mpi_serialization_test(size_t iterations)
 {
     using namespace mpi_test;
@@ -503,6 +503,48 @@ void mpi_serialization_test(size_t iterations)
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count();
 
     std::cout << "mpi: time = " << duration << " milliseconds" << std::endl << std::endl;
+}
+
+void
+yas_serialization_test(size_t iterations)
+{
+    using namespace yas_test;
+
+    Record r1, r2;
+
+    for (size_t i = 0; i < kIntegers.size(); i++) {
+        r1.ids.push_back(kIntegers[i]);
+    }
+
+    for (size_t i = 0; i < kStringsCount; i++) {
+        r1.strings.push_back(kStringValue);
+    }
+
+    std::string serialized;
+
+    to_string(r1, serialized);
+    from_string(r2, serialized);
+
+    if (r1 != r2) {
+        throw std::logic_error("yas' case: deserialization failed");
+    }
+
+    std::cout << "yas: size = " << serialized.size() << " bytes" << std::endl;
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for (size_t i = 0; i < iterations; i++) {
+        yas::mem_ostream os;
+        yas::binary_oarchive<yas::mem_ostream> oa(os);
+        oa & r1;
+
+        yas::mem_istream is(os.get_intrusive_buffer());
+        yas::binary_iarchive<yas::mem_istream> ia(is);
+        ia & r2;
+    }
+    auto finish = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count();
+
+    std::cout << "yas: time = " << duration << " milliseconds" << std::endl << std::endl;
 }
 
 int
@@ -590,6 +632,9 @@ main(int argc, char **argv)
             mpi_serialization_test(iterations);
         }
 #endif
+        if (names.empty() || names.find("yas") != names.end()) {
+            yas_serialization_test(iterations);
+        }
     } catch (std::exception &exc) {
         std::cerr << "Error: " << exc.what() << std::endl;
         return EXIT_FAILURE;

--- a/test.cpp
+++ b/test.cpp
@@ -457,10 +457,10 @@ void hpx_zero_copy_serialization_test(size_t iterations)
     from_string(r2, serialized);
 
     if (r1 != r2) {
-        throw std::logic_error("hpx's case: deserialization failed");
+        throw std::logic_error("hpx_zero_copy's case: deserialization failed");
     }
 
-    std::cout << "hpx: size = " << serialized.size() << " bytes" << std::endl;
+    std::cout << "hpx_zero_copy: size = " << serialized.size() << " bytes" << std::endl;
 
     auto start = std::chrono::high_resolution_clock::now();
     for (size_t i = 0; i < iterations; i++) {
@@ -471,7 +471,7 @@ void hpx_zero_copy_serialization_test(size_t iterations)
     auto finish = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count();
 
-    std::cout << "hpx: time = " << duration << " milliseconds" << std::endl << std::endl;
+    std::cout << "hpx_zero_copy: time = " << duration << " milliseconds" << std::endl << std::endl;
 }
 
 

--- a/yas/record.cpp
+++ b/yas/record.cpp
@@ -1,0 +1,24 @@
+#include "yas/record.hpp"
+
+namespace yas_test {
+
+void
+to_string(const Record &record, std::string &data)
+{
+    yas::mem_ostream os;
+    yas::binary_oarchive<yas::mem_ostream> oa(os);
+    oa & record;
+
+    auto buf = os.get_intrusive_buffer();
+    data.assign(buf.data, buf.size);
+}
+
+void
+from_string(Record &record, const std::string &data)
+{
+    yas::mem_istream is(data.c_str(), data.size());
+    yas::binary_iarchive<yas::mem_istream> ia(is);
+    ia & record;
+}
+
+} // namespace

--- a/yas/record.hpp
+++ b/yas/record.hpp
@@ -1,0 +1,44 @@
+#ifndef __YAS_RECORD_HPP_INCLUDED__
+#define __YAS_RECORD_HPP_INCLUDED__
+
+#include <vector>
+#include <string>
+
+#include <stdint.h>
+
+#include <yas/mem_streams.hpp>
+#include <yas/binary_iarchive.hpp>
+#include <yas/binary_oarchive.hpp>
+#include <yas/serializers/std_types_serializers.hpp>
+
+namespace yas_test {
+
+typedef std::vector<int64_t>     Integers;
+typedef std::vector<std::string> Strings;
+
+struct Record {
+
+    Integers ids;
+    Strings  strings;
+
+    bool operator==(const Record &other) {
+        return (ids == other.ids && strings == other.strings);
+    }
+
+    bool operator!=(const Record &other) {
+        return !(*this == other);
+    }
+
+    template<typename Archive>
+    void serialize(Archive &ar)
+    {
+        ar & ids & strings;
+    }
+};
+
+void to_string(const Record &record, std::string &data);
+void from_string(Record &record, const std::string &data);
+
+} // namespace
+
+#endif


### PR DESCRIPTION
Added test for YAS library (https://github.com/niXman/yas/)

Here is result on my laptop:

```
$ ./test 100000
performing 100000 iterations

thrift-binary: version = 0.9.1
thrift-binary: size = 17017 bytes
thrift-binary: time = 4231 milliseconds

thrift-compact: version = 0.9.1
thrift-compact: size = 11597 bytes
thrift-compact: time = 5423 milliseconds

protobuf: version = 2006000
protobuf: size = 12571 bytes
protobuf: time = 4539 milliseconds

capnproto: version = 5002
capnproto: size = 17768 bytes
capnproto: time = 6 milliseconds

boost: version = 105600
boost: size = 17470 bytes
boost: time = 3362 milliseconds

msgpack: version = 0.5.9
msgpack: size = 11902 bytes
msgpack: time = 4375 milliseconds

cereal: size = 17416 bytes
cereal: time = 2042 milliseconds

avro: size = 12288 bytes
avro: time = 5680 milliseconds

hpx: size = 17433 bytes
hpx: time = 2320 milliseconds

hpx_zero_copy: size = 9433 bytes
hpx_zero_copy: time = 1710 milliseconds

mpi: size = 13008 bytes
mpi: time = 2488 milliseconds

yas: size = 17012 bytes
yas: time = 816 milliseconds
```

By the way, cap'n proto test seems to be broken. Its execution time is too low, probably measuring empty loop.
